### PR TITLE
Add caching to tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,24 @@ jobs:
           repository: 'FormingWorlds/SOCRATES'
           path: 'SOCRATES'
 
+      - uses: actions/cache@v3
+        id: cache-socrates
+        with:
+          path: |
+            ~/SOCRATES/bin
+            ~/SOCRATES/sbin
+            ~/SOCRATES/set_rad_env
+          key: socrates-$( cat version )
+
+      - name: Build SOCRATES
+        if: steps.cache-socrates.outputs.cache-hit != 'true'
+        run: |
+          export LD_LIBRARY_PATH=""
+          cd SOCRATES
+          ./configure
+          ./build_code 
+          cd ..
+
       - name: Setup system
         run: |
           sudo apt update
@@ -35,15 +53,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Build SOCRATES
-        run: |
-          export LD_LIBRARY_PATH=""
-          cd SOCRATES
-          ./configure
-          ./build_code 
-          source set_rad_env
-          cd ..
 
       - uses: actions/cache@v3
         id: cache-virtualenv
@@ -59,5 +68,5 @@ jobs:
       - name: Test with pytest
         run: |
           export FWL_DATA="./fwl_data"
-          source SOCRATES/set_rad_env
+          source ~/SOCRATES/set_rad_env
           pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
             SOCRATES/bin
             SOCRATES/sbin
             SOCRATES/set_rad_env
-          key: socrates-${{ hashFiles('version') }}
+          key: socrates-${{ hashFiles('SOCRATES/version') }}
 
       - name: Build SOCRATES
         if: steps.cache-socrates.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'FormingWorlds/SOCRATES'
-          path: 'SOCRATES'
+          path: '~/SOCRATES'
 
       - uses: actions/cache@v3
         id: cache-socrates
@@ -38,7 +38,7 @@ jobs:
             ~/SOCRATES/bin
             ~/SOCRATES/sbin
             ~/SOCRATES/set_rad_env
-          key: socrates-$( cat version )
+          key: socrates-${{ hashFiles('version') }}
 
       - name: Build SOCRATES
         if: steps.cache-socrates.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup system
+        run: |
+          sudo apt update
+          sudo apt-get install libnetcdff-dev netcdf-bin gfortran gcc
+
       - name: Get SOCRATES
         uses: actions/checkout@v4
         with:
@@ -43,11 +48,6 @@ jobs:
           ./configure
           ./build_code 
           cd ..
-
-      - name: Setup system
-        run: |
-          sudo apt update
-          sudo apt-get install libnetcdff-dev netcdf-bin gfortran gcc
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,12 +67,12 @@ jobs:
       - uses: actions/cache@v3
         id: cache-fwl-data
         with:
-          path: ~/fwl_data
+          path: /home/runner/work/fwl_data
           key: fwl-data-1
 
       - name: Test with pytest
         run: |
-          export FWL_DATA="~/fwl_data"
+          export FWL_DATA="/home/runner/work/fwl_data"
           source SOCRATES/set_rad_env
           coverage run -m pytest
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           cd ..
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -64,8 +64,14 @@ jobs:
         run: |
           python -m pip install -e .[develop]
 
+      - uses: actions/cache@v3
+        id: cache-fwl-data
+        with:
+          path: ~/fwl_data
+          key: fwl-data-1
+
       - name: Test with pytest
         run: |
-          export FWL_DATA="./fwl_data"
+          export FWL_DATA="~/fwl_data"
           source SOCRATES/set_rad_env
           pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,22 +22,21 @@ jobs:
 
       - name: Setup system
         run: |
-          sudo apt update
           sudo apt-get install libnetcdff-dev netcdf-bin gfortran gcc
 
       - name: Get SOCRATES
         uses: actions/checkout@v4
         with:
           repository: 'FormingWorlds/SOCRATES'
-          path: '~/SOCRATES'
+          path: 'SOCRATES'
 
       - uses: actions/cache@v3
         id: cache-socrates
         with:
           path: |
-            ~/SOCRATES/bin
-            ~/SOCRATES/sbin
-            ~/SOCRATES/set_rad_env
+            SOCRATES/bin
+            SOCRATES/sbin
+            SOCRATES/set_rad_env
           key: socrates-${{ hashFiles('version') }}
 
       - name: Build SOCRATES
@@ -68,5 +67,5 @@ jobs:
       - name: Test with pytest
         run: |
           export FWL_DATA="./fwl_data"
-          source ~/SOCRATES/set_rad_env
+          source SOCRATES/set_rad_env
           pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,13 +45,19 @@ jobs:
           source set_rad_env
           cd ..
 
+      - uses: actions/cache@v3
+        id: cache-virtualenv
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
+
       - name: Build JANUS
+        if: steps.cache-virtualenv.outputs.cache-hit != 'true'
         run: |
-          pip install -e .
+          python -m pip install -e .[develop]
 
       - name: Test with pytest
         run: |
-          pip install pytest
           export FWL_DATA="./fwl_data"
           source SOCRATES/set_rad_env
           pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,11 @@ name: Tests for JANUS
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR sets up caching for setting up JANUS and SOCRATES. This completely eliminates build times on repeated runs with the same SOCRATES or JANUS versions. This should reduce total test times by ~1.5 minutes for each run.

The caches are keyed by the python version and `pyproject.toml` for JANUS and to `SOCRATES/version` for SOCRATES.

I also scoped the test runs, so that they no longer run twice in a PR.

Closes #37

### TODO
- [x] Cache `FWL_DATA` directory
- [x] Use absolute path for `FWL_DATA`