### PR TITLE
Set up coverage testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,4 +50,29 @@ jobs:
           pip install pytest
           export FWL_DATA="./fwl_data"
           source SOCRATES/set_rad_env
-          pytest
+          coverage run -m pytest
+
+      - name: Report coverage
+        run: |
+          coverage json
+          export TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo "total=$TOTAL" >> $GITHUB_ENV
+          echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
+          echo $'\n```' >> $GITHUB_STEP_SUMMARY
+          coverage report >> $GITHUB_STEP_SUMMARY
+          echo $'\n```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Make coverage badge
+        if: ${{ github.ref == 'refs/heads/main' && matrix.python-version == '3.10' }}
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 99391a66bb9229771504c3a4db611d05
+          filename: covbadge.svg
+          label: Coverage
+          message: ${{ env.total }}%
+          minColorRange: 50
+          maxColorRange: 90
+          valColorRange: ${{ env.total }}
+
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,11 +43,10 @@ jobs:
 
       - name: Build JANUS
         run: |
-          pip install -e .
+          python -m pip install -e .[develop]
 
       - name: Test with pytest
         run: |
-          pip install pytest
           export FWL_DATA="./fwl_data"
           source SOCRATES/set_rad_env
           coverage run -m pytest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,7 +62,7 @@ jobs:
           echo $'\n```' >> $GITHUB_STEP_SUMMARY
 
       - name: Make coverage badge
-        if: ${{ github.ref == 'refs/heads/main' && matrix.python-version == '3.10' }}
+        if: ${{ github.ref == 'refs/heads/master' && matrix.python-version == '3.10' }}
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing guidelines
+
+### Running tests
+
+JANUS uses [pytest](https://docs.pytest.org/en/latest/) to run the tests. You can run the tests for yourself using:
+
+```console
+pytest
+```
+
+To check coverage:
+
+```console
+coverage run -m pytest
+coverage report  # to output to terminal
+coverage html    # to generate html report
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Coverage](https://gist.githubusercontent.com/stefsmeets/99391a66bb9229771504c3a4db611d05/raw/covbadge.svg)
+
 ## JANUS (1D convective atmosphere model)
 
 Generates a temperature profile using the generalised moist pseudoadiabat and a prescribed stratosphere. Calculates radiative fluxes using SOCRATES.   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ homepage = "https://github.com/FormingWorlds/JANUS"
 [project.optional-dependencies]
 develop = [
   "bump-my-version",
+  "coverage[toml]",
   "pytest"
 ]
 publishing = [
@@ -58,6 +59,10 @@ publishing = [
 [tool.setuptools]
 package-dir = {"janus" = "src/janus"}
 include-package-data = true
+
+[tool.coverage.run]
+branch = true
+source = ["janus"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
This PR sets up coverage testing. I updated CONTRIBUTING.md with how to get started. The test workflow will report the coverage to the action artifacts and as a badge in the readme.

See: https://github.com/FormingWorlds/JANUS/blob/coverage/README.md

### TODO
- [x] Add GIST_TOKEN to secrets