### PR TITLE
Set up documentation on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - method: pip
+     path: .
+     extra_requirements:
+      - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ mkdocs serve
 You can find the documentation source in the [docs](https://github.com/FormingWorlds/JANUS/tree/main/docs) directory.
 If you are adding new pages, make sure to update the listing in the [`mkdocs.yml`](https://github.com/FormingWorlds/JANUS/blob/main/mkdocs.yml) under the `nav` entry.
 
+The documentation is hosted on [readthedocs](https://readthedocs.io/projects/fwl-janus).
+
 ### Running tests
 
 JANUS uses [pytest](https://docs.pytest.org/en/latest/) to run the tests. You can run the tests for yourself using:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Documentation Status](https://readthedocs.org/projects/fwl-janus/badge/?version=latest)](https://fwl-janus.readthedocs.io/en/latest/?badge=latest)
 ![Coverage](https://gist.githubusercontent.com/stefsmeets/99391a66bb9229771504c3a4db611d05/raw/covbadge.svg)
 
 ## JANUS (1D convective atmosphere model)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: JANUS
-site_url: https://fwljanus.readthedocs.io
+site_url: https://fwl-janus.readthedocs.io
 repo_url: https://github.com/FormingWorlds/JANUS
 repo_name: GitHub
 


### PR DESCRIPTION
This PR sets up documentation on readthedocs. Once this PR is merged you can see the docs on https://fwl-janus.readthedocs.io 

Test version for now: https://fwl-janus.readthedocs.io/en/rtd/