### PR TITLE
Match the README badge row to the other PROTEUS modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Docs](https://img.shields.io/github/actions/workflow/status/FormingWorlds/JANUS/docs.yaml?branch=main&label=Docs)](https://proteus-framework.org/JANUS/)
-[![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/JANUS?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/JANUS)
+[![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/JANUS/main?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/JANUS)
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/JANUS/tests.yaml?branch=main&label=Unit%20Tests)](https://github.com/FormingWorlds/JANUS/actions/workflows/tests.yaml)
 [![Integration Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/JANUS/nightly.yml?branch=main&label=Integration%20Tests)](https://github.com/FormingWorlds/JANUS/actions/workflows/nightly.yml)
-
-[![total tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/JANUS/badges/tests-total.json)](https://proteus-framework.org/validation)
-[![unit tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/JANUS/badges/tests-unit.json)](https://proteus-framework.org/validation)
-[![integration tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/JANUS/badges/tests-integration.json)](https://proteus-framework.org/validation)
 
 # JANUS
 


### PR DESCRIPTION
## Description

The README carried a second badge row with the live test counts (total, unit, integration), which the CALLIOPE, ZEPHYRUS, and Zalmoxis READMEs do not show. This removes that row so the JANUS README carries the same five badges as the other modules; the test counts remain visible on the documentation testing page. The coverage badge now queries the main branch directly so it reports the uploaded Codecov value instead of unknown.

## Validation of changes

Verified the branch-qualified Codecov badge URL resolves to the uploaded coverage value, and compared the badge row one-to-one against the CALLIOPE, ZEPHYRUS, and Zalmoxis READMEs. Markdown-only change, no code paths affected.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people

cc @nichollsh