### PR TITLE
Bump version to 26.07.13

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ authors:
   orcid: "https://orcid.org/0000-0001-5107-3531"
 
 title: "JANUS"
-version: 24.11.05
+version: 26.07.13
 doi: 10.3847/PSJ/ac214c
-date-released: 2024-11-05
+date-released: 2026-07-13
 url: "https://github.com/FormingWorlds/JANUS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fwl-janus"
-version = "24.11.05"
+version = "26.07.13"
 description = "Temperature structure generator for planetory atmospheres."
 readme = "README.md"
 authors = [

--- a/src/janus/__init__.py
+++ b/src/janus/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = '24.11.05'
+__version__ = '26.07.13'


### PR DESCRIPTION
## Description

Version bump for the 26.07.13 release, updating the package version in pyproject.toml and the package init, and the version and release date in CITATION.cff. No code changes.

## Validation of changes

`python -c "import janus; print(janus.__version__)"` reports 26.07.13 and the pyproject version parses to the same string.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people

cc @nichollsh