### PR TITLE
Key the nightly data cache on the dataset JANUS resolves

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,11 +70,36 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[develop]
 
+      # The key carries the directory fwl-io resolves for every dataset the
+      # installed fwl-mors declares, plus the checksums its registry pins, so it
+      # moves exactly when that data moves. actions/cache writes only on an
+      # exact-key miss, so a key that never changes is never rewritten and the
+      # tree it holds cannot follow the data.
+      - name: Resolve the data cache key
+        id: cachekey
+        run: python tools/nightly_data_cache.py key
+
+      # The spectral files and stellar spectra are pinned by OSF project ids in
+      # src/janus/utils/data.py, which this key does not track. The prefix
+      # restore-key seeds a moved key from the previous tree, so they are not
+      # refetched alongside a re-pinned dataset.
       - uses: actions/cache@v4
         id: cache-fwl-data
         with:
           path: /home/runner/work/fwl_data
-          key: fwl-data-1
+          key: ${{ steps.cachekey.outputs.key }}
+          restore-keys: |
+            fwl-data-
+
+      # A tree restored on an exact key hit holds what that key was stored
+      # under, so anything short of the registry means the two have come apart.
+      # A prefix restore is expected to be incomplete and is not checked. Only
+      # the manifest-declared datasets are covered, which is what the key spans.
+      - name: Check the restored track data
+        if: steps.cache-fwl-data.outputs.cache-hit == 'true'
+        run: |
+          python tools/nightly_data_cache.py check \
+            --data-root /home/runner/work/fwl_data
 
       - name: Run unit + smoke + integration + slow tests with coverage
         run: |

--- a/src/janus/utils/data.py
+++ b/src/janus/utils/data.py
@@ -52,6 +52,9 @@ def DownloadStellarSpectra():
     """
     Download stellar spectra
     """
+    # This pin sits outside the manifest the nightly cache key hashes, and the
+    # download is skipped whenever the folder is already there. Changing it
+    # therefore serves the cached spectra until that cache is cleared by hand.
     #project ID of the stellar spectra on OSF
     project_id = '8r2sw'
     folder_name = 'Named'
@@ -78,6 +81,9 @@ def DownloadSpectralFiles(fname: str="",nband: int=256):
         - nband (optional) :    number of band = 16, 48, 256, 4096
                                 (only relevant for Dayspring, Frostflow and Honeyside)
     """
+    # This pin sits outside the manifest the nightly cache key hashes, and each
+    # folder is skipped whenever it is already there. Changing it therefore
+    # serves the cached spectral files until that cache is cleared by hand.
     #project ID of the spectral files on OSF
     project_id = 'vehxg'
 

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -138,3 +138,237 @@ def test_spectral_download_basic_list_skip_and_error(tmp_path, monkeypatch):
             jdata.DownloadSpectralFiles(fname='NotADataset')
 
     assert jdata.GetFWLData() == tmp_path.absolute()
+
+
+def _cache_module():
+    """Load tools/nightly_data_cache.py, skipping when its inputs are absent."""
+    pytest.importorskip('mors')
+    pytest.importorskip('fwl_io')
+    import importlib.util
+
+    path = Path(__file__).parents[2] / 'tools' / 'nightly_data_cache.py'
+    spec = importlib.util.spec_from_file_location('nightly_data_cache', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(drc: Path, *, record: str, checksum: str) -> Path:
+    """Write a one-dataset manifest and its registry, and return the manifest."""
+    manifest = drc / 'mors_manifest.toml'
+    manifest.write_text(
+        '[star.tracks.baraffe_2015]\n'
+        'name = "Baraffe tracks"\n'
+        f'zenodo = "10.5281/zenodo.{record}"\n'
+        'required_by = ["mors"]\n',
+        encoding='utf-8',
+    )
+    registry = drc / 'star.tracks.baraffe_2015.registry.txt'
+    registry.write_text(
+        f'BHAC15-M0p010.txt md5:{checksum}\nBHAC15-M0p015.txt md5:{"b" * 32}\n',
+        encoding='utf-8',
+    )
+    return manifest
+
+
+def test_nightly_cache_key_moves_with_the_dataset_and_not_otherwise(monkeypatch, tmp_path):
+    """The cache key tracks the record pin and the checksums, and nothing else.
+
+    A key that stops moving with the data does not fail anything: the nightly
+    stays green and silently refetches every run, which is the whole defect
+    this key exists to prevent. Both directions are pinned here.
+    """
+    mod = _cache_module()
+    import mors.data
+
+    calls = []
+
+    def key_for(record: str, checksum: str, name: str = 'Baraffe tracks') -> str:
+        # A fresh directory per call, so no two cases can share a manifest and
+        # agree for that reason rather than on their inputs.
+        calls.append(record)
+        drc = tmp_path / f'pins-{len(calls)}'
+        drc.mkdir()
+        manifest = _write_manifest(drc, record=record, checksum=checksum)
+        if name != 'Baraffe tracks':
+            manifest.write_text(
+                manifest.read_text(encoding='utf-8').replace('Baraffe tracks', name),
+                encoding='utf-8',
+            )
+        monkeypatch.setattr(mors.data, 'manifest_path', lambda: manifest, raising=True)
+        return mod.resolve_key()
+
+    baseline = key_for('15729114', 'a' * 32)
+
+    # Re-pinning the record moves the data into a new r<record-id> directory.
+    assert key_for('15729115', 'a' * 32) != baseline
+    # Re-syncing the files changes the checksums without moving the directory.
+    assert key_for('15729114', 'c' * 32) != baseline
+    # A cosmetic manifest edit leaves the tree alone, so it must not cost a
+    # full refetch of a dataset that has only one upstream mirror.
+    assert key_for('15729114', 'a' * 32, name='BHAC15 tracks') == baseline
+    # Same inputs, same key: a steady-state night has to hit its own entry.
+    assert key_for('15729114', 'a' * 32) == baseline
+    # An empty digest would equal the workflow's restore-key prefix, exact-hit
+    # its own entry and freeze the tree with nothing reporting it.
+    assert baseline.startswith(mod.KEY_PREFIX)
+    assert len(baseline) > len(mod.KEY_PREFIX)
+
+
+def test_nightly_workflow_derives_its_key_and_keeps_a_restore_prefix():
+    """The workflow reads the resolved key and falls back to the shared prefix."""
+    mod = _cache_module()
+    workflow = (Path(__file__).parents[2] / '.github' / 'workflows' / 'nightly.yml').read_text(
+        encoding='utf-8'
+    )
+
+    import re
+
+    assert 'tools/nightly_data_cache.py key' in workflow
+    assert 'key: ${{ steps.cachekey.outputs.key }}' in workflow
+    # ANY literal, not just the one this replaced: actions/cache never rewrites
+    # an entry whose key it hits, so a literal of any value freezes the tree.
+    assert not re.search(rf'key:\s*{re.escape(mod.KEY_PREFIX)}\S', workflow)
+    # Without the prefix a moved key starts cold and refetches every dataset,
+    # including the OSF ones the key does not track.
+    assert 'restore-keys:' in workflow
+    assert f'\n            {mod.KEY_PREFIX}\n' in workflow
+    # The check only means something on an exact hit.
+    assert "if: steps.cache-fwl-data.outputs.cache-hit == 'true'" in workflow
+
+
+def test_cache_key_refuses_to_resolve_when_the_pins_are_missing(monkeypatch, tmp_path):
+    """Resolving without a manifest or registry stops the job with a diagnostic."""
+    mod = _cache_module()
+    import mors.data
+
+    missing = tmp_path / 'absent' / 'mors_manifest.toml'
+    monkeypatch.setattr(mors.data, 'manifest_path', lambda: missing, raising=True)
+    with pytest.raises(mod.ResolutionError, match='does not exist'):
+        mod.resolve_key()
+    assert mod.main(['key']) == 1
+
+    drc = tmp_path / 'no-registry'
+    drc.mkdir()
+    manifest = _write_manifest(drc, record='15729114', checksum='a' * 32)
+    (drc / 'star.tracks.baraffe_2015.registry.txt').unlink()
+    monkeypatch.setattr(mors.data, 'manifest_path', lambda: manifest, raising=True)
+    with pytest.raises(mod.ResolutionError, match='registry'):
+        mod.resolve_key()
+
+    empty = tmp_path / 'no-dataset'
+    empty.mkdir()
+    (empty / 'mors_manifest.toml').write_text('', encoding='utf-8')
+    monkeypatch.setattr(
+        mors.data, 'manifest_path', lambda: empty / 'mors_manifest.toml', raising=True
+    )
+    with pytest.raises(mod.ResolutionError, match='declares no dataset'):
+        mod.resolve_key()
+
+
+def test_restore_check_counts_registry_files_not_directories(monkeypatch, tmp_path):
+    """The restore check compares file counts against the registry, not existence.
+
+    A directory that exists but is short of its registry is exactly what a
+    frozen cache looks like, so presence alone must not pass.
+    """
+    mod = _cache_module()
+    import mors.data
+
+    drc = tmp_path / 'pins'
+    drc.mkdir()
+    manifest = _write_manifest(drc, record='15729114', checksum='a' * 32)
+    monkeypatch.setattr(mors.data, 'manifest_path', lambda: manifest, raising=True)
+
+    root = tmp_path / 'fwl_data'
+    target = root / 'star' / 'tracks' / 'baraffe_2015' / 'r15729114'
+    target.mkdir(parents=True)
+
+    # An empty but existing directory is the frozen-cache case.
+    assert mod.check_restored(root) == [('star/tracks/baraffe_2015/r15729114', 0, 2)]
+    assert mod.main(['check', '--data-root', str(root)]) == 1
+
+    (target / 'BHAC15-M0p010.txt').write_text('x', encoding='utf-8')
+    assert mod.check_restored(root) == [('star/tracks/baraffe_2015/r15729114', 1, 2)]
+    assert mod.main(['check', '--data-root', str(root)]) == 1
+
+    (target / 'BHAC15-M0p015.txt').write_text('x', encoding='utf-8')
+    assert mod.check_restored(root) == [('star/tracks/baraffe_2015/r15729114', 2, 2)]
+    assert mod.main(['check', '--data-root', str(root)]) == 0
+
+
+def test_key_command_writes_the_output_line_the_workflow_reads(monkeypatch, tmp_path):
+    """The key subcommand emits exactly the GITHUB_OUTPUT line the cache step consumes.
+
+    This is the one contract wiring the script to the workflow. A malformed
+    line leaves steps.cachekey.outputs.key empty, and an empty cache key means
+    the restore-key prefix always wins, so the tree either freezes or refetches
+    every night with nothing failing.
+    """
+    import re
+
+    mod = _cache_module()
+    out = tmp_path / 'gh_output'
+    monkeypatch.setenv('GITHUB_OUTPUT', str(out))
+
+    assert mod.main(['key']) == 0
+    lines = out.read_text(encoding='utf-8').splitlines()
+    assert len(lines) == 1
+    assert re.fullmatch(rf'key={re.escape(mod.KEY_PREFIX)}[0-9a-f]{{64}}', lines[0])
+    assert lines[0].split('=', 1)[1] == mod.resolve_key()
+
+    # Appended, not truncated: a second call must not lose the first line.
+    assert mod.main(['key']) == 0
+    assert len(out.read_text(encoding='utf-8').splitlines()) == 2
+
+
+def test_key_is_independent_of_registry_and_manifest_ordering(monkeypatch, tmp_path):
+    """Reordering the registry lines leaves the key alone.
+
+    Registry order is not part of the data, so a re-sync that shuffles lines
+    must not cost a full refetch of a dataset with one upstream mirror.
+    """
+    mod = _cache_module()
+    import mors.data
+
+    def key_for(lines: str, tag: str) -> str:
+        drc = tmp_path / tag
+        drc.mkdir()
+        manifest = drc / 'mors_manifest.toml'
+        manifest.write_text(
+            '[star.tracks.baraffe_2015]\n'
+            'name = "Baraffe tracks"\n'
+            'zenodo = "10.5281/zenodo.15729114"\n'
+            'required_by = ["mors"]\n',
+            encoding='utf-8',
+        )
+        (drc / 'star.tracks.baraffe_2015.registry.txt').write_text(lines, encoding='utf-8')
+        monkeypatch.setattr(mors.data, 'manifest_path', lambda: manifest, raising=True)
+        return mod.resolve_key()
+
+    first = f'BHAC15-M0p010.txt md5:{"a" * 32}\nBHAC15-M0p015.txt md5:{"b" * 32}\n'
+    reversed_lines = f'BHAC15-M0p015.txt md5:{"b" * 32}\nBHAC15-M0p010.txt md5:{"a" * 32}\n'
+    assert key_for(first, 'forward') == key_for(reversed_lines, 'reverse')
+    # Swapping which file carries which checksum IS a data change and must move it.
+    swapped = f'BHAC15-M0p010.txt md5:{"b" * 32}\nBHAC15-M0p015.txt md5:{"a" * 32}\n'
+    assert key_for(swapped, 'swapped') != key_for(first, 'forward-again')
+
+
+def test_check_refuses_to_run_without_a_data_root(monkeypatch, capsys):
+    """With no root given, check reports it rather than inspecting the working directory.
+
+    Path('') is Path('.'), so a guard applied after the Path is built cannot
+    fire and would silently count files in whatever directory the job sits in.
+    """
+    mod = _cache_module()
+    monkeypatch.delenv('FWL_DATA', raising=False)
+
+    with pytest.raises(mod.ResolutionError, match='no data root'):
+        mod._cmd_check(SimpleNamespace(data_root=None))
+    assert mod.main(['check']) == 1
+    assert 'no data root' in capsys.readouterr().err
+
+    # An empty string is the same case and must not fall through to the CWD.
+    monkeypatch.setenv('FWL_DATA', '')
+    with pytest.raises(mod.ResolutionError, match='no data root'):
+        mod._cmd_check(SimpleNamespace(data_root=None))

--- a/tools/nightly_data_cache.py
+++ b/tools/nightly_data_cache.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Cache key and restore check for the FWL data tree the nightly caches.
+
+Two subcommands, both used by ``.github/workflows/nightly.yml``::
+
+    python tools/nightly_data_cache.py key
+    python tools/nightly_data_cache.py check
+
+``key`` prints ``key=<value>`` for ``GITHUB_OUTPUT``. The value carries a
+digest of the Baraffe layout JANUS resolves through its ``fwl-mors``
+dependency: for every dataset the installed manifest declares, the
+directory fwl-io places it in and the per-file checksums the registry
+pins. It therefore moves when the data moves and stays put otherwise.
+
+Every declared dataset counts, not only the one JANUS fetches today. A
+dataset the manifest gains later costs at most one extra refetch, where
+narrowing the digest to a named subset would leave a dataset JANUS starts
+consuming untracked, which is the failure worth avoiding.
+
+``check`` verifies that every registry file is present in that resolved
+directory. The nightly runs it only on an exact-key cache hit, where a
+missing file means the restored tree does not match the key it was
+stored under.
+
+Both subcommands fail with a diagnostic rather than degrade: an empty or
+partial digest would collide with the workflow's restore-key prefix and
+freeze the cached tree with nothing reporting it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+KEY_PREFIX = 'fwl-data-'
+
+
+class ResolutionError(RuntimeError):
+    """The datasets that decide the cached layout could not be resolved."""
+
+
+def _manifest_path() -> Path:
+    """Return the dataset manifest shipped inside the installed fwl-mors.
+
+    Returns
+    -------
+    Path
+        Absolute path of ``mors_manifest.toml``.
+
+    Raises
+    ------
+    ResolutionError
+        When fwl-mors is absent, exposes no manifest, or the manifest
+        file it names does not exist.
+    """
+    try:
+        import mors.data
+    except ImportError as exc:
+        raise ResolutionError(
+            'fwl-mors is not importable, so the Baraffe layout this key tracks '
+            'cannot be resolved. Install JANUS with its dependencies before '
+            'resolving the cache key.'
+        ) from exc
+
+    if not hasattr(mors.data, 'manifest_path'):
+        raise ResolutionError(
+            'the installed fwl-mors exposes no mors.data.manifest_path(), so the '
+            'dataset pins are no longer where this script looks for them. Point it '
+            'at whatever now declares the Baraffe record and checksums.'
+        )
+
+    path = Path(mors.data.manifest_path())
+    if not path.is_file():
+        raise ResolutionError(f'the dataset manifest fwl-mors names does not exist: {path}')
+    return path
+
+
+def _fetchers(data_root: Path) -> list:
+    """Build one fwl-io fetcher per dataset the manifest declares.
+
+    Parameters
+    ----------
+    data_root : Path
+        Root the fetchers resolve their target directories below.
+
+    Returns
+    -------
+    list
+        Fetchers, ordered by dataset key.
+
+    Raises
+    ------
+    ResolutionError
+        When the manifest declares no dataset, or a declared registry
+        file is missing.
+    """
+    from fwl_io import create_fetcher, load_manifest
+
+    manifest = _manifest_path()
+    datasets = sorted(load_manifest(manifest), key=lambda ds: ds.key)
+    if not datasets:
+        raise ResolutionError(
+            f'{manifest} declares no dataset, so this key would track nothing.'
+        )
+
+    built = []
+    for ds in datasets:
+        if not Path(ds.registry_path).is_file():
+            raise ResolutionError(
+                f'dataset {ds.key!r} declares a registry at {ds.registry_path}, '
+                'which does not exist. The checksums are half of what this key '
+                'tracks, so resolving it without them would freeze the cache.'
+            )
+        built.append(
+            create_fetcher(
+                subdir=ds.subdir,
+                zenodo=ds.zenodo,
+                dataverse=ds.dataverse,
+                registry=ds.registry_path,
+                data_root=data_root,
+            )
+        )
+    return built
+
+
+def resolve_key(data_root: Path | None = None) -> str:
+    """Return the cache key for the FWL data tree.
+
+    Parameters
+    ----------
+    data_root : Path | None
+        Root passed to the fetchers. Only relative layout is hashed, so
+        any writable directory gives the same key; a temporary one is
+        used when this is None.
+
+    Returns
+    -------
+    str
+        ``fwl-data-<sha256>``.
+
+    Raises
+    ------
+    ResolutionError
+        When the datasets cannot be resolved, or the digest comes out
+        empty and would collapse the key onto the restore-key prefix.
+    """
+    if data_root is None:
+        with tempfile.TemporaryDirectory() as tmp:
+            return resolve_key(Path(tmp))
+
+    material = []
+    for f in _fetchers(data_root):
+        material.append(f'dir\t{f.rel_dir}')
+        for name in sorted(f.registry):
+            material.append(f'file\t{name}\t{f.registry[name]}')
+
+    if not material:
+        raise ResolutionError(
+            'no dataset directory or checksum was resolved, so the key would be '
+            'the bare restore-key prefix and the cached tree could never be '
+            'rewritten.'
+        )
+
+    digest = hashlib.sha256('\n'.join(material).encode('utf-8')).hexdigest()
+    return f'{KEY_PREFIX}{digest}'
+
+
+def check_restored(data_root: Path) -> list[tuple[str, int, int]]:
+    """Report how much of each dataset is present below ``data_root``.
+
+    Parameters
+    ----------
+    data_root : Path
+        Root of the restored FWL data tree.
+
+    Returns
+    -------
+    list of tuple
+        One ``(rel_dir, found, expected)`` per dataset.
+
+    Raises
+    ------
+    ResolutionError
+        When the datasets cannot be resolved.
+    """
+    report = []
+    for f in _fetchers(data_root):
+        expected = sorted(f.registry)
+        found = sum(1 for name in expected if (f.target_dir / name).is_file())
+        report.append((f.rel_dir, found, len(expected)))
+    return report
+
+
+def _cmd_key(args: argparse.Namespace) -> int:
+    key = resolve_key()
+    print(f'Cache key: {key}', file=sys.stderr)
+    output = os.environ.get('GITHUB_OUTPUT')
+    if output:
+        with open(output, 'a', encoding='utf-8') as handle:
+            handle.write(f'key={key}\n')
+    else:
+        print(f'key={key}')
+    return 0
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    # Test the argument before it becomes a Path: Path('') is Path('.'), so a
+    # guard on the Path would pass and quietly check the working directory.
+    given = args.data_root or os.environ.get('FWL_DATA')
+    if not given:
+        raise ResolutionError('no data root to check: pass --data-root or set FWL_DATA.')
+    root = Path(given)
+
+    incomplete = False
+    for rel_dir, found, expected in check_restored(root):
+        print(f'{rel_dir}: {found}/{expected} files present')
+        if found != expected:
+            incomplete = True
+
+    if incomplete:
+        print(
+            'The restored tree is missing files the registry pins, so it does not '
+            'match the key it was stored under and the nightly will refetch them '
+            'from a single upstream mirror. An exact-key hit is never re-saved, so '
+            'delete that cache entry to let the next run store a complete tree.',
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run a subcommand and return its exit status."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest='command', required=True)
+    sub.add_parser('key', help='print the cache key for the FWL data tree')
+    check = sub.add_parser('check', help='verify the restored tree against the registry')
+    check.add_argument('--data-root', default=None, help='defaults to FWL_DATA')
+
+    args = parser.parse_args(argv)
+    handler = {'key': _cmd_key, 'check': _cmd_check}[args.command]
+    try:
+        return handler(args)
+    except ResolutionError as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 -- reported, never swallowed
+        # Anything fwl-io raises reaches here. Name it rather than let a
+        # traceback stand in for the diagnostic this script promises.
+        print(
+            f'error: resolving the datasets through fwl-io failed: {exc!r}. '
+            'Check that the installed fwl-mors and fwl-io still expose the '
+            'manifest and fetcher this script reads.',
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

The nightly caches the FWL data tree under the fixed key `fwl-data-1`. `actions/cache` writes only on an exact-key miss, so a key that never changes is never rewritten: the entry has been frozen since 4 July, while the Baraffe tracks moved to a versioned layout on 20 July. Every nightly restores that stale tree, does not find the resolved directory, and fetches the tracks from Zenodo, which is why the run died when Zenodo answered 504 on 7 August.

The key now carries a digest of the directory fwl-io resolves for every dataset the installed fwl-mors declares, plus the checksums its registry pins, so it moves exactly when that data moves and stays put otherwise. A `fwl-data-` restore prefix seeds a moved key from the previous tree, so the OSF spectral files are not refetched alongside a re-pinned dataset, and a check step verifies the restored tree against the registry whenever the primary key hits exactly.

Both subcommands of `tools/nightly_data_cache.py` fail with a diagnostic rather than degrade, because an empty digest would collapse the key onto the restore prefix, exact-hit its own entry, and freeze the cache again with nothing reporting it.

## Validation of changes

Two dispatched runs on this branch, both green. Run 31151811126 logs `Cache saved with key: fwl-data-96cee3bb...`, which the old fixed key could never do. Run 31152300601 hits that key exactly, and its check step reports `star/tracks/baraffe_2015/r15729114: 31/31 files present` before any test runs, with nothing fetched from Zenodo and 291 tests passing in 180 s against 1165 s for the failing nightly. The saved entry is 508864 B larger than the stale one it was seeded from, which is the track data itself.

One thing to do on merge: cache writes are branch-scoped, so main's first nightly after this lands still misses the new key, restores the stale entry through the prefix, and fetches once more. Dispatching the nightly manually on main after merging seeds the main-scoped entry and retires that exposure the same day.

Ubuntu runner, Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
